### PR TITLE
bugfix: import execution course site without duplicated pages

### DIFF
--- a/src/main/java/pt/ist/fenix/ui/spring/TeacherPagesController.java
+++ b/src/main/java/pt/ist/fenix/ui/spring/TeacherPagesController.java
@@ -26,6 +26,7 @@ import org.fenixedu.cms.domain.Menu;
 import org.fenixedu.cms.domain.MenuItem;
 import org.fenixedu.commons.i18n.LocalizedString;
 import org.fenixedu.learning.domain.executionCourse.ExecutionCourseSite;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.JstlView;
 import org.springframework.web.servlet.view.RedirectView;
 import pt.ist.fenixframework.Atomic;
@@ -74,9 +76,16 @@ public class TeacherPagesController extends ExecutionCourseController {
 
     @RequestMapping(value = "copyContent", method = RequestMethod.POST)
     public RedirectView copyContent(@PathVariable ExecutionCourse executionCourse,
-            @RequestParam ExecutionCourse previousExecutionCourse) {
+            @RequestParam ExecutionCourse previousExecutionCourse, RedirectAttributes redirectAttributes) {
         canCopyContent(executionCourse, previousExecutionCourse);
-        copyContent(previousExecutionCourse.getSite(), executionCourse.getSite());
+        try {
+            copyContent(previousExecutionCourse.getSite(), executionCourse.getSite());
+        } catch (RuntimeException e) {
+            LoggerFactory.getLogger(TeacherPagesController.class).error("error importing site content", e);
+            //error occurred while importing content
+            redirectAttributes.addFlashAttribute("importError", true);
+            return new RedirectView(String.format("/teacher/%s/pages", executionCourse.getExternalId()), true);
+        }
         return new RedirectView(String.format("/teacher/%s/pages", executionCourse.getExternalId()), true);
     }
 
@@ -89,7 +98,7 @@ public class TeacherPagesController extends ExecutionCourseController {
         emptyPageParent.getPage().setPublished(false);
         emptyPageParent.setTop(newMenu);
         for(Menu oldMenu : from.getMenusSet()) {
-            oldMenu.getItemsSet().stream().forEach(menuItem -> service.copyStaticPage(menuItem, to, newMenu, emptyPageParent));
+            oldMenu.getToplevelItemsSorted().forEach(menuItem -> service.copyStaticPage(menuItem, to, newMenu, emptyPageParent));
         }
     }
 

--- a/src/main/webapp/WEB-INF/fenix-learning/teacherPages.jsp
+++ b/src/main/webapp/WEB-INF/fenix-learning/teacherPages.jsp
@@ -45,13 +45,21 @@ window.tooltip = $.fn.tooltip;
     <spring:message code="label.pages.management"/>
     <div class="button-group pull-right">
         <a data-toggle="modal" data-target="#copyContentModal" href="#" class="btn btn-default">
-            <span class="glyphicon glyphicon-copy" aria-hidden="true"></span> Importar Conteudo</a>
+            <span class="glyphicon glyphicon-copy" aria-hidden="true"></span> <spring:message code="action.import.site"/> </a>
 
         <a data-toggle="modal" data-target="#optionsModal" href="#" class="btn btn-default">
             <span class="glyphicon glyphicon-cog" aria-hidden="true"></span> <spring:message code="label.homepage.options" /></a>
     </div>
 </h2>
 <hr />
+<c:if test="${not empty importError}">
+    <div class="alert alert-danger" role="alert">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+        <span class="sr-only"></span>
+        <spring:message code="label.error"/> :
+        <spring:message code="label.error.tryAgain"/>
+    </div>
+</c:if>
 
 <div class="modal fade" id="optionsModal" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog">
@@ -60,7 +68,7 @@ window.tooltip = $.fn.tooltip;
                 <button type="button" class="close" data-dismiss="modal">
                     <span aria-hidden="true">&times;</span>
                     <span class="sr-only"><spring:message code="action.close"/></span></button>
-                <h4>Settings</h4>
+                <h4><spring:message code="label.settings"/></h4>
             </div>
             <form role="form" method="post" action="${teacherContext}/options" class="form-horizontal" id="homepage-publish-form">
                 <div class="modal-body">

--- a/src/main/webapp/WEB-INF/resources/IstCmsResources_en.properties
+++ b/src/main/webapp/WEB-INF/resources/IstCmsResources_en.properties
@@ -116,4 +116,5 @@ action.import=Import
 action.import.site=Import site
 message.error.page.submitted.body=
 label.select.site=Select site
+label.settings=Settings
 label.support.form=

--- a/src/main/webapp/WEB-INF/resources/IstCmsResources_pt.properties
+++ b/src/main/webapp/WEB-INF/resources/IstCmsResources_pt.properties
@@ -138,3 +138,4 @@ channels.label.name = Nome
 label.alternativeSite=Site Alternativo
 label.alternativeSite.placeholder=http\://alternativesite.edu
 action.import.site=Importar site
+label.settings=Configurações


### PR DESCRIPTION
- import algorithm was iterating over all the menu items of the site menu while it should be considering only the top-menu-items.
- added an error message when the import fails
- added some i18n labels