### PR TITLE
fixed getLabel for new thesisProposalPaticipant where user can be null if it's an external person

### DIFF
--- a/src/main/java/pt/ist/fenix/ui/spring/FenixParticipantLabelService.java
+++ b/src/main/java/pt/ist/fenix/ui/spring/FenixParticipantLabelService.java
@@ -15,6 +15,11 @@ public class FenixParticipantLabelService implements ParticipantLabelService {
     @Override
     public String getInstitutionRole(ThesisProposalParticipant participant) {
         User user = participant.getUser();
+
+        if (user == null) {
+            return null;
+        }
+
         Teacher teacher = user.getPerson().getTeacher();
 
         if (teacher != null && teacher.getTeacherAuthorization().isPresent()) {


### PR DESCRIPTION
fixed getLabel for new thesisProposalPaticipant where user can be null if it's an external person..
